### PR TITLE
Remove the lorem ipsum text that appears as a default text in the details of members who have not provided a heading or an about text

### DIFF
--- a/components/member/Details.vue
+++ b/components/member/Details.vue
@@ -5,7 +5,7 @@
       {{
         props.member.about
           ? props.member.about
-          : 'Lorem Ipsum is what the good animal did, and when they were safely on the other side, and had walked on a little while, the woods grew more and more familiar to them.'
+          : ''
       }}
     </p>
     <div v-if="props.skills.length" class="skills">

--- a/components/members/Card.vue
+++ b/components/members/Card.vue
@@ -26,7 +26,7 @@
             {{
               member.headline
                 ? member.headline
-                : 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra eu sapien et tincidunt. Nunc dui risus, tempus vel eros ut, tempor sollicitudin elit.'
+                : ''
             }}
           </p>
         </div>


### PR DESCRIPTION
Fixes #110 