### PR TITLE
Upgrade Nuxt Auth

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -63,6 +63,7 @@ export default defineNuxtConfig({
     // Keys within public, will be also exposed to the client-side
     public: {
       communityApiUrl: '',
+      authBaseUrl: '',
       targetEnv: '',
       buildCommitSha: '',
       buildCommitLink: '',
@@ -87,25 +88,22 @@ export default defineNuxtConfig({
   },
 
   auth: {
-    baseURL: process.env.NUXT_PUBLIC_AUTH_BASE_URL || '',
+    originEnvKey: 'NUXT_PUBLIC_AUTH_BASE_URL',
+    baseURL: process.env.NUXT_PUBLIC_AUTH_BASE_URL ?? '',
     provider: {
       type: 'local',
       endpoints: {
-        signIn: { path: '/login', method: 'post' },
-        signOut: { path: '/logout', method: 'get' },
-        getSession: { path: '/', method: 'get' },
+        signIn: { path: 'login', method: 'post' },
+        signOut: { path: 'logout', method: 'get' },
+        getSession: { path: '', method: 'get' },
       },
       token: {
         signInResponseTokenPointer: '/access_token',
         cookieName: 'access_token',
         type: 'Bearer',
         maxAgeInSeconds: 60 * 60 * 24,
-      },
-      sessionDataType: {
-        id: 'string',
-        username: 'string',
-        iat: 'number',
-        exp: 'number',
+        secureCookieAttribute: true,
+        httpOnlyCookieAttribute: true, // NOTE: disable in local development
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@kevinmarrec/nuxt-pwa": "^0.17.0",
         "@nuxtjs/sitemap": "^6.0.1",
         "@nuxtjs/tailwindcss": "^6.12.1",
-        "@sidebase/nuxt-auth": "^0.7.2",
+        "@sidebase/nuxt-auth": "^0.9.3",
         "@volar-plugins/vetur": "latest",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
@@ -2681,18 +2681,23 @@
       ]
     },
     "node_modules/@sidebase/nuxt-auth": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sidebase/nuxt-auth/-/nuxt-auth-0.7.2.tgz",
-      "integrity": "sha512-0f/DxRvDKFBwg5jR85KMeuVGQSygnDl3LOFeXnEHOS3A9SnJLE8najNooq7DbQB6lB8dl+vDpguVNH+V92TiHg==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@sidebase/nuxt-auth/-/nuxt-auth-0.9.3.tgz",
+      "integrity": "sha512-celbFy5j1IIFUpVQA+0CvqzxqFTdHS3SFMHnPGONzrjka0BDIDOHtMfZ7xyIgOb8OaBdibjRsqeUhhJmBYfkOA==",
       "dev": true,
       "dependencies": {
-        "@nuxt/kit": "^3.11.2",
+        "@nuxt/kit": "^3.12.4",
         "defu": "^6.1.4",
-        "h3": "^1.11.1",
+        "h3": "^1.12.0",
         "knitwork": "^1.1.0",
-        "nitropack": "^2.9.6",
+        "nitropack": "^2.9.7",
         "requrl": "^3.0.2",
-        "ufo": "^1.5.3"
+        "scule": "^1.3.0",
+        "ufo": "^1.5.4"
+      },
+      "engines": {
+        "node": ">=20",
+        "pnpm": ">=9.4.0"
       },
       "peerDependencies": {
         "next-auth": "~4.21.1"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@kevinmarrec/nuxt-pwa": "^0.17.0",
     "@nuxtjs/sitemap": "^6.0.1",
     "@nuxtjs/tailwindcss": "^6.12.1",
-    "@sidebase/nuxt-auth": "^0.7.2",
+    "@sidebase/nuxt-auth": "^0.9.3",
     "@volar-plugins/vetur": "latest",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
- Upgrade [@sidebase/nuxt-auth](https://github.com/sidebase/nuxt-auth) to v0.9.3
- Add `Secure` and `httpOnly` cookie attributes
- Remove leading `'/'` from auth endpoints [ref](https://auth.sidebase.io/guide/local/quick-start#using-an-external-backend)
- Add `authBaseUrl` as a public nuxt config variable

