### PR TITLE
Restore Auth URL Config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -105,6 +105,14 @@ export default defineNuxtConfig({
         secureCookieAttribute: true,
         httpOnlyCookieAttribute: true, // NOTE: disable in local development
       },
+      session: {
+        dataType: {
+          id: 'string',
+          username: 'string',
+          iat: 'number',
+          exp: 'number',
+        },
+      },
     },
   },
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -89,7 +89,7 @@ export default defineNuxtConfig({
 
   auth: {
     originEnvKey: 'NUXT_PUBLIC_AUTH_BASE_URL',
-    baseURL: process.env.NUXT_PUBLIC_AUTH_BASE_URL ?? '',
+    baseURL: 'https://community.api.prod.josa.ngo/v2/auth/',
     provider: {
       type: 'local',
       endpoints: {


### PR DESCRIPTION
Since Nuxt-Auth hasn't officially added this feature [yet](https://github.com/sidebase/nuxt-auth/pull/913), I'm rolling this back to be a hardcoded URL temporarily.